### PR TITLE
Variational reflectivity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .vscode
-*.csv
 *.asv

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,11 @@ catkin_package(
 ## Plugins
 add_library(nps_multibeam_sonar_ros_plugin
             src/gazebo_ros_multibeam_sonar.cpp
-            src/sonar_calculation_cuda.cu)
+            src/sonar_calculation_cuda.cu
+            src/MaterialSwitcher.cc  # From gazebo/rendering/selection_buffer
+            src/SelectionBuffer.cc  # From gazebo/rendering/selection_buffer
+            src/SelectionRenderListener.cc  # From gazebo/rendering/selection_buffer
+  )
 set_target_properties(nps_multibeam_sonar_ros_plugin
                       PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
 target_link_libraries(nps_multibeam_sonar_ros_plugin

--- a/include/nps_uw_multibeam_sonar/gazebo_ros_multibeam_sonar.hh
+++ b/include/nps_uw_multibeam_sonar/gazebo_ros_multibeam_sonar.hh
@@ -58,6 +58,12 @@
 #include <gazebo/sensors/SensorTypes.hh>
 #include <gazebo/plugins/DepthCameraPlugin.hh>
 
+// For variational reflectivity
+#include <sdf/Element.hh>
+#include <gazebo/rendering/Scene.hh>
+#include <gazebo/rendering/Visual.hh>
+#include "selection_buffer/SelectionBuffer.hh"
+
 
 namespace gazebo
 {
@@ -80,6 +86,22 @@ namespace gazebo
     /// \brief Load the plugin
     /// \param take in SDF root element
     public: virtual void Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf);
+
+    /// \brief Helper function to fill the list of fiducials with all models
+    /// in the world if none are specified
+    private: void PopulateFiducials();
+    // From FiducialCameraPlugin
+    /// \brief Selection buffer used for occlusion detection
+    public: std::unique_ptr<rendering::SelectionBuffer> selectionBuffer;
+
+    /// \brief Pointer to the scene.
+    public: rendering::ScenePtr scene;
+
+    /// \brief True to detect all objects in the world.
+    public: bool detectAll = false;
+
+    /// \brief A list of fiducials tracked by this camera.
+    public: std::set<std::string> fiducials;
 
     /// \brief Advertise point cloud and depth image
     public: virtual void Advertise();
@@ -244,5 +266,16 @@ namespace gazebo
       return 1.0;
     }
   }
+
+  /// \brief A class to store fiducial data
+  class FiducialData
+  {
+    /// \brief Fiducial ID
+    public: std::string id;
+
+    /// \brief Center point of the fiducial in the image
+    public: ignition::math::Vector2i pt;
+  };
+
 }
 #endif

--- a/include/nps_uw_multibeam_sonar/gazebo_ros_multibeam_sonar.hh
+++ b/include/nps_uw_multibeam_sonar/gazebo_ros_multibeam_sonar.hh
@@ -145,6 +145,11 @@ namespace gazebo
     private: std::string reflectivityDatabaseFilePath;
     private: std::vector<std::string> objectNames;
     private: std::vector<double> reflectivities;
+    private: double maxDepth, maxDepth_before, maxDepth_beforebefore;
+    private: double maxDepth_prev;
+    private: bool calculateReflectivity;
+    private: u_int64_t reflectivity_frameCounter;
+    private: u_int64_t reflectivity_frameInterval;
     private: cv::Mat reflectivityImage;
     private: float* rangeVector;
     private: float* window;

--- a/include/nps_uw_multibeam_sonar/gazebo_ros_multibeam_sonar.hh
+++ b/include/nps_uw_multibeam_sonar/gazebo_ros_multibeam_sonar.hh
@@ -144,12 +144,10 @@ namespace gazebo
     private: std::string reflectivityDatabaseFileName;
     private: std::string reflectivityDatabaseFilePath;
     private: std::vector<std::string> objectNames;
-    private: std::vector<double> reflectivities;
+    private: std::vector<float> reflectivities;
     private: double maxDepth, maxDepth_before, maxDepth_beforebefore;
     private: double maxDepth_prev;
     private: bool calculateReflectivity;
-    private: u_int64_t reflectivity_frameCounter;
-    private: u_int64_t reflectivity_frameInterval;
     private: cv::Mat reflectivityImage;
     private: float* rangeVector;
     private: float* window;

--- a/include/nps_uw_multibeam_sonar/gazebo_ros_multibeam_sonar.hh
+++ b/include/nps_uw_multibeam_sonar/gazebo_ros_multibeam_sonar.hh
@@ -138,7 +138,14 @@ namespace gazebo
     private: bool constMu;
     private: double absorption;
     private: double attenuation;
-    private: double mu;  // surface reflectivity
+    // constant reflectivity
+    private: double mu;
+    // variational reflectivity
+    private: std::string reflectivityDatabaseFileName;
+    private: std::string reflectivityDatabaseFilePath;
+    private: std::vector<std::string> objectNames;
+    private: std::vector<double> reflectivities;
+    private: cv::Mat reflectivityImage;
     private: float* rangeVector;
     private: float* window;
     private: float** beamCorrector;

--- a/include/nps_uw_multibeam_sonar/sonar_calculation_cuda.cuh
+++ b/include/nps_uw_multibeam_sonar/sonar_calculation_cuda.cuh
@@ -60,7 +60,7 @@ namespace NpsGazeboSonar
                                      double _sonarFreq,
                                      double _bandwidth,
                                      int _nFreq,
-                                     double _mu,
+                                     const cv::Mat &reflectivity_image,
                                      double _attenuation,
                                      float *_window,
                                      float **_beamCorrector,

--- a/include/selection_buffer/MaterialSwitcher.hh
+++ b/include/selection_buffer/MaterialSwitcher.hh
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2012 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef GAZEBO_RENDERING_SELECTIONBUFFER_MATERIALSWITCHER_HH_
+#define GAZEBO_RENDERING_SELECTIONBUFFER_MATERIALSWITCHER_HH_
+
+#include <map>
+#include <string>
+#include <ignition/math/Color.hh>
+#include "gazebo/rendering/ogre_gazebo.h"
+#include "gazebo/util/system.hh"
+
+namespace gazebo
+{
+  namespace rendering
+  {
+    /*struct cmp_color
+    {
+      bool operator()(const ignition::math::Color &_a,
+                      const ignition::math::Color &_b) const
+      {
+        return _a.AsBGRA() < _b.AsBGRA();
+      }
+    };*/
+
+    class SelectionBuffer;
+    class GZ_RENDERING_VISIBLE MaterialSwitcher :
+      public Ogre::MaterialManager::Listener
+    {
+      /// \brief Constructor
+      public: MaterialSwitcher();
+
+      /// \brief Destructor
+      public: ~MaterialSwitcher();
+
+      /// \brief Get the entity with a specific color
+      /// \param[in] _color The entity's color.
+      public: const std::string &GetEntityName(
+              const ignition::math::Color &_color) const;
+
+      /// \brief Reset the color value incrementor
+      public: void Reset();
+
+      /// \brief Ogre callback that assigns colors to new renderables
+      public: virtual Ogre::Technique *handleSchemeNotFound(
+                  uint16_t _schemeIndex, const Ogre::String &_schemeName,
+                  Ogre::Material *_originalMaterial, uint16_t _lodIndex,
+                  const Ogre::Renderable *_rend);
+
+      // private: typedef std::map<unsigned int, std::string, cmp_color>
+      // ColorMap;
+      private: typedef std::map<unsigned int, std::string> ColorMap;
+      private: typedef ColorMap::const_iterator ColorMapConstIter;
+      private: std::string emptyString;
+      private: ignition::math::Color currentColor;
+      private: std::string lastEntity;
+      private: Ogre::Technique *lastTechnique;
+      private: MaterialSwitcher::ColorMap colorDict;
+
+      private: void GetNextColor();
+
+      public: friend class SelectionBuffer;
+
+      /// \brief Plain material technique
+      private: Ogre::Technique *plainTechnique = nullptr;
+
+      /// \brief Overlay material technique
+      private: Ogre::Technique *overlayTechnique = nullptr;
+    };
+  }
+}
+#endif

--- a/include/selection_buffer/SelectionBuffer.hh
+++ b/include/selection_buffer/SelectionBuffer.hh
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2012 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef _GAZEBO_RENDERING_SELECTION_BUFFER_SELECTIONBUFFER_HH_
+#define _GAZEBO_RENDERING_SELECTION_BUFFER_SELECTIONBUFFER_HH_
+
+#include <memory>
+#include <string>
+#include "gazebo/util/system.hh"
+
+namespace Ogre
+{
+  class Entity;
+  class RenderTarget;
+  class SceneManager;
+}
+
+namespace gazebo
+{
+  namespace rendering
+  {
+    struct SelectionBufferPrivate;
+
+    class GZ_RENDERING_VISIBLE SelectionBuffer
+    {
+      /// \brief Constructor
+      /// \param[in] _camera Name of the camera to generate a selection
+      /// buffer for.
+      /// \param[in] _mgr Pointer to the scene manager.
+      /// \param[in] _renderTarget Pointer to the render target.
+      public: SelectionBuffer(const std::string &_cameraName,
+                  Ogre::SceneManager *_mgr, Ogre::RenderTarget *_renderTarget);
+
+      /// \brief Destructor
+      public: ~SelectionBuffer();
+
+      /// \brief Handle on mouse click
+      /// \param[in] _x X coordinate in pixels.
+      /// \param[in] _y Y coordinate in pixels.
+      /// \return Returns the Ogre entity at the coordinate.
+      public: Ogre::Entity *OnSelectionClick(int _x, int _y);
+
+      /// \brief Debug show overlay
+      /// \param[in] _show True to show the selection buffer in an overlay.
+      public: void ShowOverlay(bool _show);
+
+      /// \brief Call this to update the selection buffer contents
+      public: void Update();
+
+      /// \brief Delete the render texture
+      private: void DeleteRTTBuffer();
+
+      /// \brief Create the render texture
+      private: void CreateRTTBuffer();
+
+      /// \brief Create the selection buffer offscreen render texture.
+      private: void CreateRTTOverlays();
+
+      /// \internal
+      /// \brief Pointer to private data.
+      private: std::unique_ptr<SelectionBufferPrivate> dataPtr;
+    };
+  }
+}
+#endif

--- a/include/selection_buffer/SelectionRenderListener.hh
+++ b/include/selection_buffer/SelectionRenderListener.hh
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2012 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef _SELECTIONRENDERLISTENER_HH_
+#define _SELECTIONRENDERLISTENER_HH_
+
+#include "gazebo/rendering/ogre_gazebo.h"
+#include "gazebo/util/system.hh"
+
+namespace gazebo
+{
+  namespace rendering
+  {
+    class MaterialSwitcher;
+    // We need this attached to the depth target, otherwise we get problems with
+    // the compositor MaterialManager.Listener should NOT be running all the
+    // time - rather only when we're specifically rendering the target that
+    // needs it
+    class GZ_RENDERING_VISIBLE SelectionRenderListener :
+      public Ogre::RenderTargetListener
+    {
+      /// \brief Constructor
+      public: explicit SelectionRenderListener(MaterialSwitcher *_switcher);
+
+      /// \brief Destructor
+      public: ~SelectionRenderListener();
+
+      public: virtual void preRenderTargetUpdate(
+                  const Ogre::RenderTargetEvent &_evt);
+
+      public: virtual void postRenderTargetUpdate(
+                  const Ogre::RenderTargetEvent &_evt);
+
+      private: MaterialSwitcher *materialListener;
+    };
+  }
+}
+#endif

--- a/models/blueview_p900_nps_multibeam/model.sdf
+++ b/models/blueview_p900_nps_multibeam/model.sdf
@@ -61,9 +61,9 @@
           <soundSpeed>1500</soundSpeed>
           <sourceLevel>220</sourceLevel>
           <maxDistance>10</maxDistance>
-          <constantReflectivity>false</constantReflectivity>
+          <constantReflectivity>true</constantReflectivity>
           <!-- The CSV databsefile is located at the worlds folder -->
-          <reflectivityDatabaseFileName>variationalReflectivityDatabase</reflectivityDatabaseFileName>
+          <reflectivityDatabaseFile>variationalReflectivityDatabase.csv</reflectivityDatabaseFile>
           <raySkips>10</raySkips>
           <sensorGain>0.02</sensorGain>
           <plotScaler>10</plotScaler>

--- a/models/blueview_p900_nps_multibeam/model.sdf
+++ b/models/blueview_p900_nps_multibeam/model.sdf
@@ -61,7 +61,9 @@
           <soundSpeed>1500</soundSpeed>
           <sourceLevel>220</sourceLevel>
           <maxDistance>10</maxDistance>
-          <constantReflectivity>true</constantReflectivity>
+          <constantReflectivity>false</constantReflectivity>
+          <!-- The CSV databsefile is located at the worlds folder -->
+          <reflectivityDatabaseFileName>variationalReflectivityDatabase</reflectivityDatabaseFileName>
           <raySkips>10</raySkips>
           <sensorGain>0.02</sensorGain>
           <plotScaler>10</plotScaler>

--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
 
   <depend version_gte="2.5.17">gazebo_ros</depend>
   <depend>gazebo_dev</depend>
+  <depend>gazebo_plugins</depend>
   <depend>uuv_sensor_ros_plugins</depend>
   <depend>gazebo_msgs</depend>
   <depend>sensor_msgs</depend>

--- a/src/MaterialSwitcher.cc
+++ b/src/MaterialSwitcher.cc
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2012 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "gazebo/common/Console.hh"
+#include "gazebo/rendering/ogre_gazebo.h"
+#include "gazebo/rendering/RenderTypes.hh"
+
+#include "selection_buffer/MaterialSwitcher.hh"
+
+using namespace gazebo;
+using namespace rendering;
+
+/////////////////////////////////////////////////
+MaterialSwitcher::MaterialSwitcher()
+: lastTechnique(nullptr)
+{
+  this->currentColor = ignition::math::Color(0.0, 0.0, 0.1);
+}
+
+/////////////////////////////////////////////////
+MaterialSwitcher::~MaterialSwitcher()
+{
+}
+
+/////////////////////////////////////////////////
+Ogre::Technique *MaterialSwitcher::handleSchemeNotFound(
+    uint16_t /*_schemeIndex*/, const Ogre::String & /*_schemeName*/,
+    Ogre::Material *_originalMaterial, uint16_t /*_lodIndex*/,
+    const Ogre::Renderable *_rend)
+{
+  if (_rend)
+  {
+    if (typeid(*_rend) == typeid(Ogre::SubEntity))
+    {
+      const Ogre::SubEntity *subEntity =
+        static_cast<const Ogre::SubEntity *>(_rend);
+
+      if (!(subEntity->getParent()->getVisibilityFlags() &
+          GZ_VISIBILITY_SELECTABLE))
+      {
+        const_cast<Ogre::SubEntity *>(subEntity)->setCustomParameter(1,
+            Ogre::Vector4(0, 0, 0, 0));
+        return nullptr;
+      }
+
+      if (this->lastEntity == subEntity->getParent()->getName())
+      {
+        const_cast<Ogre::SubEntity *>(subEntity)->setCustomParameter(1,
+            Ogre::Vector4(this->currentColor.R(), this->currentColor.G(),
+                          this->currentColor.B(), 1.0));
+      }
+      else
+      {
+        // load the selection buffer material
+        if (this->plainTechnique == nullptr)
+        {
+          // plain opaque material
+          Ogre::ResourcePtr res =
+            Ogre::MaterialManager::getSingleton().load("gazebo/plain_color",
+                Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+
+          // OGRE 1.9 changes the shared pointer definition
+          #if (OGRE_VERSION < ((1 << 16) | (9 << 8) | 0))
+          Ogre::MaterialPtr plainMaterial = static_cast<Ogre::MaterialPtr>(res);
+          #else
+          Ogre::MaterialPtr plainMaterial = res.staticCast<Ogre::Material>();
+          #endif
+
+          this->plainTechnique = plainMaterial->getTechnique(0);
+          Ogre::Pass *plainPass = this->plainTechnique->getPass(0);
+          plainPass->setDepthCheckEnabled(true);
+          plainPass->setDepthWriteEnabled(true);
+
+          // overlay material
+          Ogre::MaterialPtr overlayMaterial =
+              plainMaterial->clone("plain_color_overlay");
+          this->overlayTechnique =
+              overlayMaterial->getTechnique(0);
+          if (!this->overlayTechnique || !this->overlayTechnique->getPass(0))
+          {
+            gzerr << "Problem creating the selection buffer overlay material"
+                << std::endl;
+            return nullptr;
+          }
+          Ogre::Pass *overlayPass = this->overlayTechnique->getPass(0);
+          overlayPass->setDepthCheckEnabled(false);
+          overlayPass->setDepthWriteEnabled(false);
+        }
+
+        // Make sure we keep the same depth properties so that
+        // certain overlay objects can be picked by the mouse.
+        Ogre::Technique *newTechnique = this->plainTechnique;
+
+        Ogre::Technique *originalTechnique = _originalMaterial->getTechnique(0);
+        if (originalTechnique)
+        {
+          Ogre::Pass *originalPass = originalTechnique->getPass(0);
+          if (originalPass)
+          {
+            // check if it's an overlay material by assuming the
+            // depth check and depth write properties are off.
+            bool depthCheck = originalPass->getDepthCheckEnabled();
+            bool depthWrite = originalPass->getDepthWriteEnabled();
+            if (!depthCheck && !depthWrite)
+              newTechnique = this->overlayTechnique;
+          }
+        }
+
+        this->lastTechnique = newTechnique;
+
+        this->GetNextColor();
+
+        const_cast<Ogre::SubEntity *>(subEntity)->setCustomParameter(1,
+            Ogre::Vector4(this->currentColor.R(), this->currentColor.G(),
+              this->currentColor.B(), 1.0));
+
+        this->lastEntity = subEntity->getParent()->getName();
+        this->colorDict[this->currentColor.AsRGBA()] = this->lastEntity;
+      }
+
+      return this->lastTechnique;
+    }
+    // else
+    //    gzerr << "Object is not a SubEntity["
+    //          << _rend->getMaterial()->getName() << "] Type[" <<
+    //          typeid(*_rend).name() << "]\n";
+  }
+  // else
+  //  gzerr << "Rendering scheme without a Renderable: " << _schemeName
+  //        << ", " + _originalMaterial->getName() << std::endl;
+  return nullptr;
+}
+
+/////////////////////////////////////////////////
+const std::string &MaterialSwitcher::GetEntityName(
+    const ignition::math::Color &_color) const
+{
+  ColorMapConstIter iter = this->colorDict.find(_color.AsRGBA());
+
+  if (iter != this->colorDict.end())
+    return (*iter).second;
+  else
+    return this->emptyString;
+}
+
+/////////////////////////////////////////////////
+void MaterialSwitcher::GetNextColor()
+{
+  auto color = this->currentColor.AsARGB();
+  color++;
+  this->currentColor.SetFromARGB(color);
+}
+
+/////////////////////////////////////////////////
+void MaterialSwitcher::Reset()
+{
+  this->currentColor = ignition::math::Color(0.0, 0.0, 0.1);
+  this->lastEntity.clear();
+  this->colorDict.clear();
+}

--- a/src/SelectionBuffer.cc
+++ b/src/SelectionBuffer.cc
@@ -1,0 +1,311 @@
+/*
+ * Copyright (C) 2012 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <memory>
+#include <ignition/math/Color.hh>
+
+#include "gazebo/common/Console.hh"
+#include "gazebo/rendering/ogre_gazebo.h"
+#include "gazebo/rendering/RenderTypes.hh"
+#include "selection_buffer/SelectionRenderListener.hh"
+#include "selection_buffer/MaterialSwitcher.hh"
+#include "selection_buffer/SelectionBuffer.hh"
+
+using namespace gazebo;
+using namespace rendering;
+
+namespace gazebo
+{
+  namespace rendering
+  {
+    struct SelectionBufferPrivate
+    {
+      /// \brief This is the material listener - Note: it is controlled by a
+      /// separate RenderTargetListener, not applied globally to all
+      /// targets. The class associates a color to an ogre entity
+      std::unique_ptr<MaterialSwitcher> materialSwitchListener;
+
+      /// \brief A render target listener that sets up the material switcher
+      /// to run on every update of this render target.
+      std::unique_ptr<SelectionRenderListener> selectionTargetListener;
+
+      /// \brief Ogre scene manager
+      Ogre::SceneManager *sceneMgr = nullptr;
+
+      /// \brief Pointer to the camera that will be used as the reference
+      /// for selection
+      Ogre::Camera *camera = nullptr;
+
+      /// \brief Selection buffer's render to texture camera
+      Ogre::Camera *selectionCamera  = nullptr;
+
+      /// \brief Ogre render target
+      Ogre::RenderTarget *renderTarget  = nullptr;
+
+      /// \brief Ogre texture
+      Ogre::TexturePtr texture;
+
+      /// \brief Ogre render texture
+      Ogre::RenderTexture *renderTexture  = nullptr;
+
+      /// \brief Render texture data buffer
+      uint8_t *buffer = nullptr;
+
+      /// \brief Ogre pixel box that contains description of the data buffer
+      Ogre::PixelBox *pixelBox = nullptr;
+
+      /// \brief A 2D overlay used for debugging the selection buffer. It
+      /// is hidden by default.
+      Ogre::Overlay *selectionDebugOverlay;
+    };
+  }
+}
+
+/////////////////////////////////////////////////
+SelectionBuffer::SelectionBuffer(const std::string &_cameraName,
+    Ogre::SceneManager *_mgr, Ogre::RenderTarget *_renderTarget)
+: dataPtr(new SelectionBufferPrivate)
+{
+  this->dataPtr->sceneMgr = _mgr;
+  this->dataPtr->renderTarget = _renderTarget;
+
+  this->dataPtr->camera = this->dataPtr->sceneMgr->getCamera(_cameraName);
+
+  this->dataPtr->selectionCamera =
+      this->dataPtr->sceneMgr->createCamera(_cameraName + "_selection_buffer");
+
+  this->dataPtr->materialSwitchListener.reset(new MaterialSwitcher());
+  this->dataPtr->selectionTargetListener.reset(new SelectionRenderListener(
+      this->dataPtr->materialSwitchListener.get()));
+  this->CreateRTTBuffer();
+  this->CreateRTTOverlays();
+}
+
+/////////////////////////////////////////////////
+SelectionBuffer::~SelectionBuffer()
+{
+  this->DeleteRTTBuffer();
+
+  // remove selection buffer camera
+  this->dataPtr->sceneMgr->destroyCamera(this->dataPtr->selectionCamera);
+}
+
+/////////////////////////////////////////////////
+void SelectionBuffer::Update()
+{
+  if (!this->dataPtr->renderTexture)
+    return;
+
+  this->dataPtr->materialSwitchListener->Reset();
+
+  // FIXME: added try-catch block to prevent crash in deferred rendering mode.
+  // RTT does not like VPL.material as it references a texture in the compositor
+  // pipeline. A possible workaround is to add the deferred rendering
+  // compositors to the renderTexture
+  try
+  {
+    this->dataPtr->renderTexture->update();
+  }
+  catch(...)
+  {
+  }
+
+  this->dataPtr->renderTexture->copyContentsToMemory(*this->dataPtr->pixelBox,
+      Ogre::RenderTarget::FB_FRONT);
+}
+
+/////////////////////////////////////////////////
+void SelectionBuffer::DeleteRTTBuffer()
+{
+  if (!this->dataPtr->texture.isNull() && this->dataPtr->texture->isLoaded())
+    this->dataPtr->texture->unload();
+  if (this->dataPtr->buffer)
+  {
+    delete [] this->dataPtr->buffer;
+    this->dataPtr->buffer = nullptr;
+  }
+  if (this->dataPtr->pixelBox)
+    delete this->dataPtr->pixelBox;
+}
+
+/////////////////////////////////////////////////
+void SelectionBuffer::CreateRTTBuffer()
+{
+  try
+  {
+    // 1x1 pixel buffer
+    unsigned int width = 1;
+    unsigned int height = 1;
+
+    this->dataPtr->texture = Ogre::TextureManager::getSingleton().createManual(
+        "SelectionPassTex",
+        Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
+        Ogre::TEX_TYPE_2D, width, height, 0, Ogre::PF_R8G8B8,
+        Ogre::TU_RENDERTARGET);
+  }
+  catch(...)
+  {
+    this->dataPtr->renderTexture = NULL;
+    gzerr << "Unable to create selection buffer.\n";
+    return;
+  }
+
+  this->dataPtr->renderTexture =
+    this->dataPtr->texture->getBuffer()->getRenderTarget();
+  this->dataPtr->renderTexture->setAutoUpdated(false);
+  this->dataPtr->renderTexture->setPriority(0);
+  this->dataPtr->renderTexture->addViewport(this->dataPtr->selectionCamera);
+  this->dataPtr->renderTexture->getViewport(0)->setOverlaysEnabled(false);
+  this->dataPtr->renderTexture->getViewport(0)->setShadowsEnabled(false);
+  this->dataPtr->renderTexture->getViewport(0)->setClearEveryFrame(true);
+  this->dataPtr->renderTexture->addListener(
+      this->dataPtr->selectionTargetListener.get());
+  this->dataPtr->renderTexture->getViewport(0)->setMaterialScheme("aa");
+  this->dataPtr->renderTexture->getViewport(0)->setVisibilityMask(
+      GZ_VISIBILITY_SELECTABLE);
+  Ogre::HardwarePixelBufferSharedPtr pixelBuffer =
+    this->dataPtr->texture->getBuffer();
+  size_t bufferSize = pixelBuffer->getSizeInBytes();
+
+  this->dataPtr->buffer = new uint8_t[bufferSize];
+  this->dataPtr->pixelBox = new Ogre::PixelBox(pixelBuffer->getWidth(),
+      pixelBuffer->getHeight(), pixelBuffer->getDepth(),
+      pixelBuffer->getFormat(), this->dataPtr->buffer);
+}
+
+/////////////////////////////////////////////////
+Ogre::Entity *SelectionBuffer::OnSelectionClick(int _x, int _y)
+{
+  if (!this->dataPtr->renderTexture)
+    return NULL;
+
+  unsigned int targetWidth = this->dataPtr->renderTarget->getWidth();
+  unsigned int targetHeight = this->dataPtr->renderTarget->getHeight();
+
+  if (_x < 0 || _y < 0 || _x >= static_cast<int>(targetWidth)
+      || _y >= static_cast<int>(targetHeight))
+    return nullptr;
+
+  // 1x1 selection buffer, adapted from rviz
+  // http://docs.ros.org/indigo/api/rviz/html/c++/selection__manager_8cpp.html
+  unsigned int width = 1;
+  unsigned int height = 1;
+  float x1 = static_cast<float>(_x) /
+      static_cast<float>(targetWidth - 1) - 0.5f;
+  float y1 = static_cast<float>(_y) /
+      static_cast<float>(targetHeight - 1) - 0.5f;
+  float x2 = static_cast<float>(_x+width) /
+      static_cast<float>(targetWidth - 1) - 0.5f;
+  float y2 = static_cast<float>(_y+height) /
+      static_cast<float>(targetHeight - 1) - 0.5f;
+  Ogre::Matrix4 scaleMatrix = Ogre::Matrix4::IDENTITY;
+  Ogre::Matrix4 transMatrix = Ogre::Matrix4::IDENTITY;
+  scaleMatrix[0][0] = 1.0 / (x2-x1);
+  scaleMatrix[1][1] = 1.0 / (y2-y1);
+  transMatrix[0][3] -= x1+x2;
+  transMatrix[1][3] += y1+y2;
+  this->dataPtr->selectionCamera->setCustomProjectionMatrix(true,
+      scaleMatrix * transMatrix * this->dataPtr->camera->getProjectionMatrix());
+  this->dataPtr->selectionCamera->setPosition(
+      this->dataPtr->camera->getDerivedPosition());
+  this->dataPtr->selectionCamera->setOrientation(
+      this->dataPtr->camera->getDerivedOrientation());
+  Ogre::Viewport* renderViewport = this->dataPtr->renderTexture->getViewport(0);
+  renderViewport->setDimensions(0, 0, width, height);
+
+  // update render texture
+  this->Update();
+
+  size_t posInStream = 0;
+
+  ignition::math::Color::BGRA color(0);
+  if (!this->dataPtr->buffer)
+  {
+    gzerr << "Selection buffer is null.\n";
+    return nullptr;
+  }
+  memcpy(static_cast<void *>(&color), this->dataPtr->buffer + posInStream, 4);
+  ignition::math::Color cv;
+  cv.SetFromARGB(color);
+  cv.A(1.0);
+  const std::string &entName =
+    this->dataPtr->materialSwitchListener->GetEntityName(cv);
+
+  if (entName.empty())
+    return 0;
+  else
+    return this->dataPtr->sceneMgr->getEntity(entName);
+}
+
+/////////////////////////////////////////////////
+void SelectionBuffer::CreateRTTOverlays()
+{
+  Ogre::OverlayManager *mgr = Ogre::OverlayManager::getSingletonPtr();
+
+  if (mgr && mgr->getByName("SelectionDebugOverlay"))
+    return;
+
+  Ogre::MaterialPtr baseWhite =
+    Ogre::MaterialManager::getSingleton().getDefaultSettings();
+
+  Ogre::MaterialPtr selectionBufferTexture =
+    baseWhite->clone("SelectionDebugMaterial");
+  Ogre::TextureUnitState *textureUnit =
+    selectionBufferTexture->getTechnique(0)->getPass(0)->
+    createTextureUnitState();
+  textureUnit->setTextureName("SelectionPassTex");
+
+  this->dataPtr->selectionDebugOverlay = mgr->create("SelectionDebugOverlay");
+
+  Ogre::OverlayContainer *panel =
+    static_cast<Ogre::OverlayContainer *>(
+        mgr->createOverlayElement("Panel", "SelectionDebugPanel"));
+
+  if (panel)
+  {
+    panel->setMetricsMode(Ogre::GMM_PIXELS);
+    panel->setPosition(10, 10);
+    panel->setDimensions(400, 280);
+    panel->setMaterialName("SelectionDebugMaterial");
+#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR  <= 9
+    this->dataPtr->selectionDebugOverlay->add2D(panel);
+    this->dataPtr->selectionDebugOverlay->hide();
+#endif
+  }
+  else
+  {
+    gzlog << "Unable to create selection buffer overlay. "
+      "This will not effect Gazebo unless you're trying to debug "
+      "the selection buffer.\n";
+  }
+}
+
+/////////////////////////////////////////////////
+#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR  <= 9
+void SelectionBuffer::ShowOverlay(bool _show)
+{
+  if (_show)
+    this->dataPtr->selectionDebugOverlay->show();
+  else
+    this->dataPtr->selectionDebugOverlay->hide();
+}
+#else
+void SelectionBuffer::ShowOverlay(bool /*_show*/)
+{
+  gzerr << "Selection debug overlay disabled for Ogre > 1.9\n";
+}
+#endif

--- a/src/SelectionRenderListener.cc
+++ b/src/SelectionRenderListener.cc
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2012 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#include "selection_buffer/SelectionRenderListener.hh"
+#include "selection_buffer/MaterialSwitcher.hh"
+
+using namespace gazebo;
+using namespace rendering;
+
+/////////////////////////////////////////////////
+SelectionRenderListener::SelectionRenderListener(MaterialSwitcher *_switcher)
+  : materialListener(_switcher)
+{
+}
+
+/////////////////////////////////////////////////
+SelectionRenderListener::~SelectionRenderListener()
+{
+}
+
+/////////////////////////////////////////////////
+void SelectionRenderListener::preRenderTargetUpdate(
+    const Ogre::RenderTargetEvent &/*_evt*/)
+{
+  Ogre::MaterialManager::getSingleton().addListener(this->materialListener);
+}
+
+/////////////////////////////////////////////////
+void SelectionRenderListener::postRenderTargetUpdate(
+    const Ogre::RenderTargetEvent &/*_evt*/)
+{
+  Ogre::MaterialManager::getSingleton().removeListener(this->materialListener);
+}

--- a/src/gazebo_ros_multibeam_sonar.cpp
+++ b/src/gazebo_ros_multibeam_sonar.cpp
@@ -34,6 +34,9 @@
 #include <sdf/sdf.hh>
 #include <gazebo/sensors/SensorTypes.hh>
 
+#include <gazebo/rendering/Scene.hh>
+#include <gazebo/rendering/Visual.hh>
+
 #include <algorithm>
 #include <string>
 #include <vector>

--- a/worlds/variationalReflectivityDatabase.csv
+++ b/worlds/variationalReflectivityDatabase.csv
@@ -1,0 +1,5 @@
+﻿# Information
+Information about this data can be written here (in one line without comma)
+# ObjectName, reflectivity (ObjecName may not be equal to that of the model name in the world file. Double check at world tab on the the left of gazebo window, defualt 0.001)
+basement_tank_model,0.00001
+cylinder_target,0.001


### PR DESCRIPTION
### New feature : Variational reflectivity
#### Related issue : [Variational surface reflectivity #2](https://github.com/Field-Robotics-Lab/nps_uw_multibeam_sonar/issues/2)
Although high fidelity target strength is beyond reach for simple implementation, a user can give different surface reflectivity on the scene's objects with this PR.

#### How it works
  - The parameter to switch the feature is defined at `model.sdf` of the sonar model (in this case, `nps_uw_multibeam_sonar/models/blueview_p900_nps_multibeam/model.sdf`
    - https://github.com/Field-Robotics-Lab/nps_uw_multibeam_sonar/blob/65a8ed35f0f09b7c9bd94c6764d7dca33f86e1af/models/blueview_p900_nps_multibeam/model.sdf#L64-L66
  - Values are defined for each model object in the world. The values are defined using the CSV file in the worlds folder. The default value is 0.001
    - https://github.com/Field-Robotics-Lab/nps_uw_multibeam_sonar/blob/65a8ed35f0f09b7c9bd94c6764d7dca33f86e1af/worlds/variationalReflectivityDatabase.csv#L4-L5
  - `cv::Mat this->reflectivityImage` is calculated if the scene is changed (it detects the change by comparing the maximum depth value of the depth camera with the previous scene. If the value is stabled (if equal for 3 consecutive frames, the calculation is performed once)
  - The `reflectivityImage` OpenCV matrix is then transferred to GPU memory and used for sonar calculation

#### Results
![image](https://user-images.githubusercontent.com/7955120/107112875-baa36280-680f-11eb-863f-df3e6acda0c6.png)


@mabelzhang  
Thank you! for the support! It was amazing to show comprehensive copy&paste-able code hints and advice for the optimization!