### PR TITLE
Change rand_image generation algorithm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ endif()
 
 find_package(catkin REQUIRED COMPONENTS
  tf
+ cv_bridge
  gazebo_plugins
  acoustic_msgs)
 

--- a/include/nps_uw_multibeam_sonar/gazebo_ros_multibeam_sonar.hh
+++ b/include/nps_uw_multibeam_sonar/gazebo_ros_multibeam_sonar.hh
@@ -128,6 +128,7 @@ namespace gazebo
                                      cv::Vec3f normal);
     private: cv::Mat ComputeNormalImage(cv::Mat& depth);
     private: void ComputeCorrector();
+    private: cv::Mat rand_image;
 
     /// \brief Parameters for sonar properties
     private: double sonarFreq;

--- a/src/gazebo_ros_multibeam_sonar.cpp
+++ b/src/gazebo_ros_multibeam_sonar.cpp
@@ -378,6 +378,13 @@ void NpsGazeboRosMultibeamSonar::Load(sensors::SensorPtr _parent,
       _sdf->GetElement("debugFlag")->Get<bool>();
 
   // -- Pre calculations for sonar -- //
+  // rand number generator
+  this->rand_image = cv::Mat(this->height, this->width, CV_32FC2);
+  uint64 randN = static_cast<uint64>(std::rand());
+  cv::theRNG().state = randN;
+  cv::RNG rng = cv::theRNG();
+  rng.fill(this->rand_image, cv::RNG::NORMAL, 0.f, 1.f);
+
   // Hamming window
   this->window = new float[this->nFreq];
   float windowSum = 0;
@@ -599,6 +606,12 @@ void NpsGazeboRosMultibeamSonar::OnNewImageFrame(const unsigned char *_image,
     {
       this->calculateReflectivity = true;
       this->maxDepth_prev = this->maxDepth;
+
+      // Regenerate reand image
+      uint64 randN = static_cast<uint64>(std::rand());
+      cv::theRNG().state = randN;
+      cv::RNG rng = cv::theRNG();
+      rng.fill(this->rand_image, cv::RNG::NORMAL, 0.f, 1.f);
     }
     else
       this->calculateReflectivity = false;
@@ -697,13 +710,6 @@ void NpsGazeboRosMultibeamSonar::ComputeSonarImage(const float *_src)
   double hFOV = this->parentSensor->DepthCamera()->HFOV().Radian();
   double vPixelSize = vFOV / this->height;
   double hPixelSize = hFOV / this->width;
-
-  // rand number generator
-  cv::Mat rand_image = cv::Mat(depth_image.rows, depth_image.cols, CV_32FC2);
-  uint64 randN = static_cast<uint64>(std::rand());
-  cv::theRNG().state = randN;
-  cv::RNG rng = cv::theRNG();
-  rng.fill(rand_image, cv::RNG::NORMAL, 0.f, 1.f);
 
   if (this->beamCorrectorSum == 0)
     ComputeCorrector();


### PR DESCRIPTION
@crvogt Can you try this out for me?

It's simple change and **it builds fine**. But I get runtime error saying `gzserver: symbol lookup error: /home/woensug/uuv_ws/devel/lib/libnps_multibeam_sonar_ros_plugin.so: undefined symbol: _ZN2cv3Mat6createEiPKii` 

It crashes at a line which isn't new at all.
https://github.com/Field-Robotics-Lab/nps_uw_multibeam_sonar/blob/a9eff3c81df070e14812f202e74d408c63b671a0/src/gazebo_ros_multibeam_sonar.cpp#L382

Maybe my computer problem (running on WSL, or gazebo version...)

Background:
The `rand_image` which was randomized at every sonar calculation should only be calculated whenever the vehicle position is changed.
@kerednoslo  's thankful comments
> if the medium is static then the scatterers should have the same amplitudes across all frames. If the robot platform moves, then the scatterers will add up in different ways and the speckle pattern will change. But if the geometry is held fixed, the speckle should be the same. This is a real feature of acoustic measurements, and is exploited in a variety of navigation methods (called the redundant phase center, or displaced phase center technique), and even in medical ultrasound (called speckle tracking). ML methods should (eventually) be able to use this property of the acoustic data as well.

