### PR TITLE
Diverse viewport/half-power vertical FOV

### DIFF
--- a/include/nps_uw_multibeam_sonar/gazebo_ros_multibeam_sonar.hh
+++ b/include/nps_uw_multibeam_sonar/gazebo_ros_multibeam_sonar.hh
@@ -139,6 +139,7 @@ namespace gazebo
     private: bool constMu;
     private: double absorption;
     private: double attenuation;
+    private: double verticalFOV;
     // constant reflectivity
     private: double mu;
     // variational reflectivity

--- a/models/blueview_m450_nps_multibeam/model.sdf
+++ b/models/blueview_m450_nps_multibeam/model.sdf
@@ -42,8 +42,8 @@
           <image>
             <width>512</width>
             <!-- Set vertical FOV by setting image height -->
-            <!-- For 10 deg. -->
-            <height>57</height>
+            <!-- Approx 2 times the spec sheet (sepc: 10 deg.) -->
+            <height>114</height>
             <format>R8G8B8</format>
           </image>
           <clip>
@@ -59,6 +59,7 @@
         </camera>
         <plugin filename="libnps_multibeam_sonar_ros_plugin.so" name="forward_sonar">
           <!-- Sonar properties -->
+          <verticalFOV>10</verticalFOV>
           <sonarFreq>450e3</sonarFreq>
           <bandwidth>29.9e3</bandwidth>
           <soundSpeed>1500</soundSpeed>

--- a/models/blueview_p900_nps_multibeam/model.sdf
+++ b/models/blueview_p900_nps_multibeam/model.sdf
@@ -39,8 +39,8 @@
           <image>
             <width>512</width>
             <!-- Set vertical FOV by setting image height -->
-            <!-- For 20 deg. -->
-            <height>114</height>
+            <!-- Approx 2 times the spec sheet (sepc: 20 deg.) -->
+            <height>228</height>
             <format>R8G8B8</format>
           </image>
           <clip>
@@ -56,6 +56,7 @@
         </camera>
         <plugin filename="libnps_multibeam_sonar_ros_plugin.so" name="forward_sonar">
           <!-- Sonar properties -->
+          <verticalFOV>20</verticalFOV>
           <sonarFreq>900e3</sonarFreq>
           <bandwidth>29.9e3</bandwidth>
           <soundSpeed>1500</soundSpeed>

--- a/models/oculus_m1200d_nps_multibeam/model.sdf
+++ b/models/oculus_m1200d_nps_multibeam/model.sdf
@@ -39,8 +39,8 @@
           <image>
             <width>256</width>
             <!-- Set vertical FOV by setting image height -->
-            <!-- For 12 deg. -->
-            <height>51</height>
+            <!-- Approx 2 times the spec sheet (sepc: 12 deg.) -->
+            <height>102</height>
             <format>R8G8B8</format>
           </image>
           <clip>
@@ -56,6 +56,7 @@
         </camera>
         <plugin filename="libnps_multibeam_sonar_ros_plugin.so" name="forward_sonar">
           <!-- Sonar properties -->
+          <verticalFOV>12</verticalFOV>
           <sonarFreq>2100e3</sonarFreq>
           <bandwidth>265.5e3</bandwidth>
           <soundSpeed>1500</soundSpeed>

--- a/models/seabat_f50_nps_multibeam/model.sdf
+++ b/models/seabat_f50_nps_multibeam/model.sdf
@@ -41,12 +41,13 @@
           <image>
             <width>256</width>
             <!-- Set vertical FOV by setting image height -->
-            <height>1</height>
+            <!-- Approx 1 times the spec sheet (sepc: 24 deg.) -->
+            <height>43</height>
             <format>R8G8B8</format>
           </image>
           <clip>
             <near>2</near>            <!-- not defined -->
-            <far>250</far>
+            <far>60</far>
           </clip>
           <depth_camera>
             <output>depths</output>
@@ -57,6 +58,7 @@
         </camera>
         <plugin filename="libnps_multibeam_sonar_ros_plugin.so" name="forward_sonar">
           <!-- Sonar properties -->
+          <verticalFOV>24</verticalFOV>
           <sonarFreq>400e3</sonarFreq>
           <bandwidth>29.9e3</bandwidth>
           <soundSpeed>1500</soundSpeed>

--- a/src/gazebo_ros_multibeam_sonar.cpp
+++ b/src/gazebo_ros_multibeam_sonar.cpp
@@ -182,6 +182,11 @@ void NpsGazeboRosMultibeamSonar::Load(sensors::SensorPtr _parent,
       _sdf->GetElement("sonarImageTopicName")->Get<std::string>();
 
   // Read sonar properties from model.sdf
+  if (!_sdf->HasElement("verticalFOV"))
+    this->verticalFOV = 10;  // Blueview P900 -> 10 degrees
+  else
+    this->verticalFOV =
+      _sdf->GetElement("verticalFOV")->Get<double>();
   if (!_sdf->HasElement("sonarFreq"))
     this->sonarFreq = 900e3;  // Blueview P900 [Hz]
   else
@@ -732,7 +737,7 @@ void NpsGazeboRosMultibeamSonar::ComputeSonarImage(const float *_src)
                   hFOV,          // hFOV
                   vFOV,          // VFOV
                   hPixelSize,    // _beam_azimuthAngleWidth
-                  vFOV,          // _beam_elevationAngleWidth
+                  verticalFOV/180*M_PI,  // _beam_elevationAngleWidth
                   hPixelSize,    // _ray_azimuthAngleWidth
                   vPixelSize*(raySkips+1),  // _ray_elevationAngleWidth
                   this->soundSpeed,    // _soundSpeed

--- a/worlds/sonar_tank_blueview_m450_nps_multibeam.world
+++ b/worlds/sonar_tank_blueview_m450_nps_multibeam.world
@@ -7,7 +7,7 @@
     <include>
       <uri>model://sun</uri>
     </include>
-    
+
     <gui>
       <camera name='user_camera'>
         <pose>9.0 3.4 7.5 0.0 0.75 3.1</pose>
@@ -24,7 +24,7 @@
     <!-- cylinder target -->
     <include>
       <uri>model://cylinder_target</uri>
-      <pose>2.1 5.0 1.0 0 0 0</pose>
+      <pose>2.1 5.0 2.0 0 0 0</pose>
       <static>true</static>
     </include>
 
@@ -32,7 +32,7 @@
     <include>
       <uri>model://blueview_m450_nps_multibeam</uri>
       <name>blueview_m450</name>
-      <pose>2.1 1.0 1.0 0 0 1.5709</pose>
+      <pose>2.1 1.0 2.0 0 0 1.5709</pose>
       <static>true</static>
     </include>
 

--- a/worlds/sonar_tank_blueview_p900_nps_multibeam.world
+++ b/worlds/sonar_tank_blueview_p900_nps_multibeam.world
@@ -25,7 +25,7 @@
     <include>
       <uri>model://cylinder_target</uri>
       <name>cylinder_target1</name>
-      <pose>2.8 5.0 1.0 0 0 0</pose>
+      <pose>2.8 5.0 2.0 0 0 0</pose>
       <static>true</static>
     </include>
 
@@ -33,7 +33,7 @@
     <include>
       <uri>model://cylinder_target</uri>
       <name>cylinder_target2</name>
-      <pose>1.5 5.0 1.0 0 1.5709 0</pose>
+      <pose>1.5 5.0 2.0 0 1.5709 0</pose>
       <static>true</static>
     </include>
 
@@ -41,7 +41,7 @@
     <include>
       <uri>model://blueview_p900_nps_multibeam</uri>
       <name>blueview_p900</name>
-      <pose>2.1 1.0 1.2 0 0 1.5709</pose>
+      <pose>2.1 1.0 2.0 0 0 1.5709</pose>
       <static>true</static>
     </include>
 

--- a/worlds/sonar_tank_seabat_f50_nps_multibeam.world
+++ b/worlds/sonar_tank_seabat_f50_nps_multibeam.world
@@ -7,7 +7,7 @@
     <include>
       <uri>model://sun</uri>
     </include>
-    
+
     <gui>
       <camera name='user_camera'>
         <pose>9.0 3.4 7.5 0.0 0.75 3.1</pose>
@@ -24,7 +24,7 @@
     <!-- cylinder target -->
     <include>
       <uri>model://cylinder_target</uri>
-      <pose>2.1 5.0 1.0 0 0 0</pose>
+      <pose>2.1 5.0 1.5 0 0 0</pose>
       <static>true</static>
     </include>
 
@@ -32,7 +32,7 @@
     <include>
       <uri>model://seabat_f50_nps_multibeam</uri>
       <name>seabat_f50</name>
-      <pose>2.1 1.0 1.0 0 0 1.5709</pose>
+      <pose>2.1 1.0 2.5 0 0 1.5709</pose>
       <static>true</static>
     </include>
 


### PR DESCRIPTION
This PR attempts to diverse the vertical FOV that of the viewport and the half-power beam pattern calculation.

Unlike the azimuthal angle direction beam pattern, in which each beam's half-power angle width is as small as 0.25 degrees for each beam, the elevation beam pattern is assumed to be equal to the vertical FOV of the spec sheet, i.e. 10~20 degrees. Therefore, the actual sonar experiment data is still showing objects that are out of spec sheet vertical FOV that is out of half-power beam pattern vertical angle. This modification adds another parameter `verticalFOV` that defines half-power beam pattern angle in a vertical angle different from the vertical viewport angle used in the depth camera. For azimuthal direction, it is neglected due to small beamwidth.