### PR TITLE
SonarImage must be attached to a Fore-Stbd-Down frame

### DIFF
--- a/src/gazebo_ros_multibeam_sonar.cpp
+++ b/src/gazebo_ros_multibeam_sonar.cpp
@@ -842,8 +842,11 @@ void NpsGazeboRosMultibeamSonar::ComputeSonarImage(const float *_src)
   {
     for (size_t beam = 0; beam < nBeams; beam ++)
     {
-      Intensity[beam][f] = static_cast<int>(this->sensorGain * abs(P_Beams[beam][f]));
-      uchar counts = static_cast<uchar>(std::min(UCHAR_MAX, Intensity[beam][f]));
+      // Serialize beams in reverse order to flip the data left to right
+      const size_t beam_idx = nBeams-beam-1;
+      Intensity[beam_idx][f] = static_cast<int>(this->sensorGain * abs(P_Beams[beam_idx][f]));
+      uchar counts = static_cast<uchar>(std::min(UCHAR_MAX, Intensity[beam_idx][f]));
+
       intensities.push_back(counts);
     }
   }


### PR DESCRIPTION
Data in the SonarImage message is defined to be in a Fore-Starboard-Down ("down") frame where X is "forward" from the sonar, and Z is "down".   In the conventional case where a forward looking sonar is installed horizontally, azimuth values comply with the nautical standard where negative azimuths are left of forward, and positive are right of forward.

The NPS sonar simulator plugin is built on top of the Gazebo depth camera plugin, which is attached to an Fore-Left-Up ("upright") frame.

In the image below, the sonar is pointed slightly to the left of the cinder block, and is attached to the upright frame shown in RViz.   The image from the depth camera (lower center) is upright, with the brick to the right of center, and the sonar image (lower left, as drawn by sonar_image_proc) is also right of center. 

![Screenshot_2021-12-10_14-35-26](https://user-images.githubusercontent.com/122743/145651904-c0af0b12-7761-47b5-bbe9-cd3ef5178ff8.png)

However, the `frame_id` placed in the header of SonarImage data is the frame of the depth camera, which is upright.   If the data is reprojected into space using this upright frame, azimuths are interpreted incorrectly with negative right of forward and positive left of forward, and the data is mirrored left to right.    

This can be seen in the image below, where the sonar data has been projected as a pointcloud relative to the frame named in the SonarImage header, the upright depth camera frame.  Viewed from above, the simulated cinderblock is at the origin, whereas the reprojected sonar data is mirrored left to right.

![rviz_screenshot_2021_12_09-22_27_08](https://user-images.githubusercontent.com/122743/145652931-40ba5751-b4a2-47dc-bd48-d5feb3a2cbf5.png)

The simplest solution is to define that the plugin **must** be attached to an down frame.  But this has the following consequences:

* The frame in the SonarImage message, which it receives from the simulator, will be consistent with the message specification
* The depth camera image will rolled by 180 deg.  This doesn't affect plugin output *unless* the sonar is given a vertical aperture which is asymmetrical up vs down -- in which case the sense of the plus- and minus- aperture will be upside down from expected.
* The SonarImages generated by the plugin **must**  be flipped in software left to right relative to previous behavior
* **This mirroring of the SonarImage is a breaking change for existing users of the plugin with the sonar attached to an upright frame**

After making these changes, the equivalent screenshot is as follows.  The simulator is now attached to the fore-right-down frame shown in RViz.   The sonar imagery (left) appears the same, while the depth camera image (right) is now upside down.  

![Screenshot_2021-12-10_14-37-41](https://user-images.githubusercontent.com/122743/145651931-e891911a-dfd6-43c6-bbfc-6bdf4fcf6067.png)

If we observe the sonar data reprojected into RViz, the cinder block is now correctly reprojected onto the origin:

![rviz_screenshot_2021_12_09-22_12_37](https://user-images.githubusercontent.com/122743/145652899-7d95f21a-4bb6-4385-8452-d2c229a08c6d.png)

The  alternative is for later processing to explicitly ignore the frame specified in the SonarImage data and instead substitute a different, manually specified frame.