### PR TITLE
Add artifical vechile vibration and fix rand image refresh condition

### DIFF
--- a/include/nps_uw_multibeam_sonar/gazebo_ros_multibeam_sonar.hh
+++ b/include/nps_uw_multibeam_sonar/gazebo_ros_multibeam_sonar.hh
@@ -150,6 +150,7 @@ namespace gazebo
     private: double maxDepth, maxDepth_before, maxDepth_beforebefore;
     private: double maxDepth_prev;
     private: bool calculateReflectivity;
+    private: bool artificialVehicleVibration;
     private: cv::Mat reflectivityImage;
     private: float* rangeVector;
     private: float* window;

--- a/models/blueview_p900_nps_multibeam/model.sdf
+++ b/models/blueview_p900_nps_multibeam/model.sdf
@@ -71,6 +71,7 @@
           <writeLog>false</writeLog>
           <debugFlag>false</debugFlag>
           <writeFrameInterval>5</writeFrameInterval>
+          <artificialVehicleVibration>false</artificialVehicleVibration>
           <!-- This name is prepended to ROS topics -->
           <cameraName>blueview_p900</cameraName>
           <!-- ROS publication topics -->


### PR DESCRIPTION
For those who need the previous sparkling noise on the static scene. This change will add the artificial vibration to the vehicle triggering the Gaussian noise random values to refresh on every frame.

Wiki edited accordingly.